### PR TITLE
Add nodeSelector and over-subscribe cores

### DIFF
--- a/.dask/config.yaml
+++ b/.dask/config.yaml
@@ -14,10 +14,12 @@ distributed:
 
 kubernetes:
   count:
-    max: 30
+    max: 50
   worker-template:
     metadata:
     spec:
+      nodeSelector:
+        dask-worker: True
       restartPolicy: Never
       containers:
       - args:
@@ -36,5 +38,5 @@ kubernetes:
             cpu: "1.75"
             memory: 7G
           requests:
-            cpu: "1.75"
+            cpu: 1
             memory: 7G


### PR DESCRIPTION
In an effort to increase the smoothness of scaling up and down we do two
things:

1.  We add a nodeSelector on the worker template to have it go to a particular
    node pool that is well suited to run workers.  This node pool has a rich
    memory-to-cpu ratio, and is intentionally separate from the user notebook
    pool.

2.  We oversaturate cores, so that we may promise more cores to users than we
    actually have.  This makes sense if users tend to have low-compute
    intensive workloads or have bursty workloads that rarely overlap.

We also increase the maximum scalability limit to 50 workers by default.

See Also: https://github.com/pangeo-data/pangeo/issues/437

cc @jhamman @tomaugspurger